### PR TITLE
Add moveit_ci Travis config. Maintainer update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci/ package.
+sudo: required
+dist: trusty
+services:
+  - docker
+language: generic
+compiler:
+  - gcc
+notifications:
+  email:
+    recipients:
+      - dave@dav.ee
+      - 130s@2000.jukuin.keio.ac.jp
+env:
+  matrix:
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall
+# matrix:
+#   allow_failures:
+#     - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu         UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall
+before_script:
+  - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
+script:
+  - source .moveit_ci/travis.sh

--- a/package.xml
+++ b/package.xml
@@ -5,6 +5,7 @@
   <description>The household_objects_database_msgs package</description>
 
   <maintainer email="matei.ciocarlie@gmail.com">Matei Ciocarlie</maintainer>
+  <maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I. Y. Saito</maintainer>
 
   <license>BSD</license>
 


### PR DESCRIPTION
@davetcoleman 
- I was already half-way done when I noticed that this is message-only repo, but might as well move on since there shouldn't be no harm.
- I'm only adding check for Kinetic (since I'm not sure how to add I-J support using moveit_ci.
- Travis needs enabled https://travis-ci.org/profile/ros-interactive-manipulation (I don't seem to have access rights).
